### PR TITLE
Use raise_with_backtrace instead of raise

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -13,5 +13,5 @@
  (description "PPX syntax for untyped effects in OCaml 5.0")
  (documentation "https://craigfe.github.io/ppx-effects")
  (depends
-  (ocaml-variants (= 4.12.0+domains))
+  (ocaml-base-compiler (>= 5.0))
   (ppxlib (and (>= 0.12.0)))))

--- a/ppx_effects.opam
+++ b/ppx_effects.opam
@@ -10,7 +10,7 @@ doc: "https://craigfe.github.io/ppx-effects"
 bug-reports: "https://github.com/CraigFe/ppx_effects/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml-variants" {= "4.12.0+domains"}
+  "ocaml-base-compiler" {>= "5.0"}
   "ppxlib" {>= "0.12.0"}
   "odoc" {with-doc}
 ]

--- a/src/ppx_effects.ml
+++ b/src/ppx_effects.ml
@@ -80,7 +80,7 @@ module Cases = struct
              ppat_desc =
                Ppat_construct
                  ( effect,
-                   Some ([], { ppat_desc = Ppat_var { txt = "k"; _ }; _ }) );
+                   Some { ppat_desc = Ppat_var { txt = "k"; _ }; _ } );
              _;
             } ->
                 raise_errorf ~loc "%s.@,Hint: did you mean %a?" error_prefix
@@ -284,13 +284,13 @@ let impl : structure -> structure =
 let effect_decl_of_exn_decl ~loc (exn : type_exception) : type_extension =
   let name = exn.ptyexn_constructor.pext_name in
   let eff_type = Located.lident ~loc "Stdlib.Effect.t" in
-  let constrs, v, args =
+  let constrs, args =
     match exn.ptyexn_constructor.pext_kind with
-    | Pext_decl (constrs, v, body) ->
+    | Pext_decl (constrs, body) ->
         let body =
           Option.map (fun typ -> ptyp_constr ~loc eff_type [ typ ]) body
         in
-        (constrs, body, v)
+        (constrs, body)
     | Pext_rebind _ ->
         raise_errorf ~loc "cannot process effect defined as an alias of %a."
           pp_quoted name.txt
@@ -298,7 +298,7 @@ let effect_decl_of_exn_decl ~loc (exn : type_exception) : type_extension =
   let params = [ (ptyp_any ~loc, (NoVariance, NoInjectivity)) ] in
   type_extension ~loc ~path:eff_type ~params
     ~constructors:
-      [ extension_constructor ~loc ~name ~kind:(Pext_decl (constrs, args, v)) ]
+      [ extension_constructor ~loc ~name ~kind:(Pext_decl (constrs, args)) ]
     ~private_:Public
 
 let str_effect_decl =

--- a/src/ppx_effects_runtime.ml
+++ b/src/ppx_effects_runtime.ml
@@ -1,7 +1,9 @@
 (** These functions are exported for use by the [ppx_effects] PPX. They are not
     intended to be called directly by users. *)
 
-let raise = Stdlib.raise
+let raise e =
+  let bt = Printexc.get_raw_backtrace () in
+  Printexc.raise_with_backtrace e bt
 
 open Stdlib.Effect.Deep
 


### PR DESCRIPTION
Hey,

when an exception is raised within a continuation the backtrace is lost as we catch the exception and simply re-raise it. This PR exchanges `Stdlib.raise` by `Printexc.raise_with_backtrace` so this information is not lost.
I'm not sure exactly how large the performance impact is but it should be insignificant. In addition, I assume it is even cheaper if backtraces are currently not recorded or the exception was raised with `Stdlib.raise_notrace`.