### PR TITLE
Support unreachable cases

### DIFF
--- a/src/ppx_effects.ml
+++ b/src/ppx_effects.ml
@@ -51,7 +51,10 @@ module Cases = struct
         in
         match body with
         | [%pat? [%p? eff_pattern], [%p? k_pattern]] ->
-            let pc_rhs =
+          let pc_rhs =
+            match case.pc_rhs.pexp_desc with
+            | Pexp_unreachable -> case.pc_rhs
+            | _ ->
               let loc = case.pc_rhs.pexp_loc in
               [%expr
                 Some


### PR DESCRIPTION
This is to support the following pattern matching case. We should use the unreachable expression directly instead of generating a closure.
```ocaml
| [%effect E _, _] -> .
```
(This can happen when parts of the data carried by the effect `E` is empty.)